### PR TITLE
Bump rspec-instafail dependency to 0.1.8 minimum.

### DIFF
--- a/fuubar.gemspec
+++ b/fuubar.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "fuubar"
-  s.version     = '0.0.5'
+  s.version     = '0.0.6'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Nicholas Evans", "Jeff Kreeftmeijer"]
   s.email       = ["jeff@kreeftmeijer.nl"]
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rspec', ["~> 2.0"])
   s.add_dependency('ruby-progressbar', ["~> 0.0.10"])
-  s.add_dependency('rspec-instafail', ["~> 0.1.4"])
+  s.add_dependency('rspec-instafail', ["~> 0.1.8"])
 end


### PR DESCRIPTION
Rspec-instafail 0.1.8 appears to be backwards compatible, and includes a
fix that makes it compatible with rspec 2.2 and on
