### PR TITLE
use the last version of ruby-progressbar gem

### DIFF
--- a/fuubar.gemspec
+++ b/fuubar.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('rspec', ["~> 2.0"])
-  s.add_dependency('ruby-progressbar', ["~> 0.0.10"])
+  s.add_dependency('ruby-progressbar', ["~> 0.11.0"])
   s.add_dependency('rspec-instafail', ["~> 0.2.0"])
 end


### PR DESCRIPTION
Old verisons of ruby-progressbar occur SystemStackError in some cases
