### PR TITLE
Print color end esc seq only when colors enabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,3 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in fuubar.gemspec
 gemspec
-
-group :development do
-  gem 'guard-rspec'
-  gem 'libnotify', require: nil
-  gem 'ruby-inotify', require: nil
-end

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,0 @@
-guard 'rspec', :version => 2, :cli => '--format documentation --color' do
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec" }
-end


### PR DESCRIPTION
Printing "\e[0m" is not a problem for major terminal emulators, but not for Emacs' dump terminal... Progress bar is just not shown when fuubar works inside Emacs' terminal, even when colors are disabled.

With this patch a user is able to disable colors and have progress bar displayed in Emacs.
