### PR TITLE
fix gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Installation
 First:
 
 ```ruby
-gem install ruby-progressbar
+gem install fuubar
 ```
 
 or in your Gemfile
 
 ```ruby
-gem 'ruby-progressbar'
+gem 'fuubar'
 ```
 
 Then, when running rspec:


### PR DESCRIPTION
Not exactly sure why the gem name is `ruby-progressbar` in the README but using that when I modified my `.rspec` file to use the `Fuubar` format I got a load error saying no such file is found.  When I changed the gem name to `fuubar` all was good.
