### PR TITLE
Depend on rspec-core, not rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "http://rubygems.org"
 gemspec
 
 gem 'rake'
+gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     fuubar (2.0.0)
       rspec (~> 3.0)
-      ruby-progressbar (~> 1.4)
+      ruby-progressbar (~> 1.4, < 1.7)
 
 GEM
   remote: http://rubygems.org/
@@ -22,7 +22,7 @@ GEM
     rspec-mocks (3.0.3)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.3)
-    ruby-progressbar (1.5.1)
+    ruby-progressbar (1.6.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fuubar (2.0.0)
-      rspec (~> 3.0)
+      rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4, < 1.7)
 
 GEM
@@ -30,3 +30,4 @@ PLATFORMS
 DEPENDENCIES
   fuubar!
   rake
+  rspec

--- a/fuubar.gemspec
+++ b/fuubar.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.require_paths         = ['lib']
 
   s.add_dependency              'rspec',              '~> 3.0'
-  s.add_dependency              'ruby-progressbar',   '~> 1.4'
+  s.add_dependency              'ruby-progressbar',   '~> 1.4', '< 1.7'
 end

--- a/fuubar.gemspec
+++ b/fuubar.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.executables           = Dir.glob("bin/*").map{ |f| File.basename(f) }
   s.require_paths         = ['lib']
 
-  s.add_dependency              'rspec',              '~> 3.0'
+  s.add_dependency              'rspec-core',         '~> 3.0'
   s.add_dependency              'ruby-progressbar',   '~> 1.4', '< 1.7'
 end

--- a/lib/fuubar.rb
+++ b/lib/fuubar.rb
@@ -1,4 +1,3 @@
-require 'rspec'
 require 'rspec/core/formatters/base_text_formatter'
 require 'ruby-progressbar'
 


### PR DESCRIPTION
I have an application that has a dependency on `rspec-rails` and `fuubar`. The former depends directly on `rspec-core` while the latter depends on `rspec`, which then depends on `rspec-core`.

When I try to upgrade my app’s `rspec-rails` dependency, I get this error from running `bundle update rspec-rails`:

```
Bundler could not find compatible versions for gem "rspec-expectations":
  In Gemfile:
    fuubar (~> 2.0) ruby depends on
      rspec (~> 3.0) ruby depends on
        rspec-expectations (~> 3.0.0) ruby

    rspec-rails (~> 3.1.0) ruby depends on
      rspec-expectations (3.1.0)
```

Depending directly on `rspec-core` should (hopefully) fix that problem.

Also, this library isn’t compatible with `ruby-progressbar` version 1.7 and higher.