### PR TITLE
Change CONTINUOUS_INTEGRATION flag to CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,5 @@
 machine:
   timezone: Greenwich
-  environment:
-    CONTINUOUS_INTEGRATION: true
   post:
     - "echo 'IFS=\"|\" && export CHAMBER_KEY=\"$(echo -e $CHAMBER_KEY)\"' >> .circlerc"
 

--- a/lib/fuubar.rb
+++ b/lib/fuubar.rb
@@ -121,8 +121,8 @@ class Fuubar < RSpec::Core::Formatters::BaseTextFormatter
   end
 
   def continuous_integration?
-    @continuous_integration ||= !(ENV['CONTINUOUS_INTEGRATION'].nil?       ||
-                                  ENV['CONTINUOUS_INTEGRATION'] == ''      ||
-                                  ENV['CONTINUOUS_INTEGRATION'] == 'false')
+    @continuous_integration ||= !(ENV['CI'].nil?       ||
+                                  ENV['CI'] == ''      ||
+                                  ENV['CI'] == 'false')
   end
 end

--- a/spec/fuubar_spec.rb
+++ b/spec/fuubar_spec.rb
@@ -53,7 +53,7 @@ describe Fuubar do
       throttle_rate: 0.0,
     }
 
-    ENV.delete('CONTINUOUS_INTEGRATION')
+    ENV.delete('CI')
   end
 
   context 'when it is created' do
@@ -85,7 +85,7 @@ describe Fuubar do
     context 'and continuous integration is enabled' do
       before do
         RSpec.configuration.fuubar_progress_bar_options = { length: 40 }
-        ENV['CONTINUOUS_INTEGRATION'] = 'true'
+        ENV['CI'] = 'true'
       end
 
       it 'throttles the progress bar at one second' do
@@ -116,7 +116,7 @@ describe Fuubar do
     context 'and continuous integration is not enabled' do
       before do
         RSpec.configuration.fuubar_progress_bar_options = { length: 40 }
-        ENV['CONTINUOUS_INTEGRATION'] = 'false'
+        ENV['CI'] = 'false'
       end
 
       it 'throttles the progress bar at the default rate' do


### PR DESCRIPTION
While Travis sets both `CI` and `CONTINUOUS_INTEGRATION` to true by default, Circle only sets `CI` to true. This change will make fuubar work out of the box on both.

More info:
- https://docs.travis-ci.com/user/environment-variables/
- https://circleci.com/docs/environment-variables