### PR TITLE
Use proper namespace for EmptyLineAfterGuardClause cop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,89 @@
+engines:
+  brakeman:
+    enabled: false
+
+  bundler-audit:
+    enabled: true
+
+  csslint:
+    enabled: false
+
+  duplication:
+    enabled: true
+
+    config:
+      languages:
+        - 'ruby'
+        - 'javascript'
+
+  eslint:
+    enabled: true
+
+    config:
+      extensions:
+        - '.es6'
+        - '.js'
+
+  fixme:
+    enabled: true
+
+    config:
+      strings:
+        - 'BUG'
+        - 'FIXME'
+        - 'HACK'
+        - 'XXX'
+
+  flog:
+    enabled: false
+
+  markdownlint:
+    enabled: true
+
+  rubocop:
+    enabled: false
+
+  scss-lint:
+    enabled: true
+
+  shellcheck:
+    enabled: true
+
+  stylelint:
+    enabled: false
+
+  tailor:
+    enabled: false
+
+  vint:
+    enabled: true
+
+ratings:
+  paths:
+    - '**.md'
+    - '**.rake'
+    - '**.rb'
+    - '**.scss'
+    - '**.swift'
+    - '**.vim'
+    - '**.bash'
+    - '**.sh'
+    - '**.zsh'
+    - '**.es6'
+    - '**.js'
+
+exclude_paths:
+  - '**/.github/**/*'
+  - '**/bin/deploy'
+  - '**/bin/setup'
+  - '**/db/migrate/**/*'
+  - '**/db/schema.rb'
+  - '**/db/structure.sql'
+  - '**/public/**/*'
+  - '**/scripts/**/*'
+  - '**/vendor/**/*'
+  - '.overcommit.yml'
+  - '.rubocop.yml'
+  - '.rubocop_core.yml'
+  - '.rubocop_rails.yml'
+  - 'spec/**/*'

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -42,4 +42,4 @@ Ideally, a bug report should include a pull request with failing specs.
 [branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [pr]: https://help.github.com/articles/using-pull-requests/
 
-Inspired by https://github.com/thoughtbot/factory_girl/blob/master/CONTRIBUTING.md
+Inspired by https://github.com/thoughtbot/factory_bot/blob/master/CONTRIBUTING.md

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,34 @@
+<!--- Well formatted issues help everyone.  Take a few minutes to get a -->
+<!--- primer on markdown here: http://bit.ly/2lB1raW -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain how the app works now -->
+
+### Steps to Reproduce <!--- ONLY NEEDED FOR BUGS. OTHERWISE DELETE THIS SECTION. -->
+<!--- Provide a set of user actions to reproduce the bug -->
+1. Sign in as "marty@hillvalley.net"
+2. Click "Current Orders"
+3. Try to remove "Flux Capacitor" from the cart
+
+### Screenshot(s)
+<!--- Add some screenshots of what the app is currently doing. -->
+<!--- -->
+<!--- How to Add Images to Issues: http://bit.ly/2mdlWHn -->
+<!--- How to Take Screenshots (Mac): http://apple.co/2kOXyuG -->
+<!--- How to Take Screenshots (Windows): http://cnet.co/2m2yQZL -->
+
+## Expected Behavior or New Behavior
+<!--- Tell us what the user should see -->
+
+### Context <!--- ONLY NEEDED FOR NEW FEATURES. OTHERWISE DELETE THIS SECTION. -->
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful -->
+<!--- in the real world. -->
+
+### Mockup(s)
+<!--- Attach marked-up screenshots, photos of sketches, etc -->
+<!--- -->
+<!--- How to Add Images to Issues: http://bit.ly/2mdlWHn -->
+<!--- How to Take Screenshots (Mac): http://apple.co/2kOXyuG -->
+<!--- How to Take Screenshots (Windows): http://cnet.co/2m2yQZL -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--- Well formatted issues help everyone.  Take a few minutes to get a -->
+<!--- primer on markdown here: http://bit.ly/2lB1raW -->
+
+## Why This Change Is Necessary
+
+<!--- Identify the High Level Type of Change -->
+- [ ] Bug Fix
+- [ ] New Feature
+
+<!--- Now describe to reviewers of your pull request what to expect in the -->
+<!--- PR, thereby allowing them to more easily identify and point out -->
+<!--- unrelated changes. -->
+
+## How These Changes Address the Issue
+<!--- Describe, at a high level, what was done to affect change. -->
+<!--- If your change is obvious, you may be able to omit addressing this. -->
+
+## Side Effects Caused By This Change
+
+- [ ] This Causes a Breaking Change
+
+<!--- This is the most important topic to answer, as it can point out -->
+<!--- problems where you are making too many changes in one commit or branch. -->
+<!--- One or two bullet points for related changes may be okay, but five or -->
+<!--- six are likely indicators of a PR that is doing too many things. -->
+
+## Screenshots
+<!--- Add screenshots of changes to the UI if appropriate, otherwise delete -->
+<!--- this section. -->
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that -->
+<!--- apply. -->
+- [ ] I have run `rubocop` against the codebase
+- [ ] I have added tests to cover my changes
+- [ ] All new and existing tests passed

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Vendored Dependencies
+Pods
 bower_components
 node_modules
 site/web/app/mu-plugins
@@ -14,7 +15,6 @@ Thumbs.db
 *.gemfile.lock
 capybara*
 pickle-email-*.html
-public/assets
 public/uploads
 rerun.txt
 site/web/app/uploads
@@ -44,12 +44,6 @@ tmtags
 variables.sls
 
 # Local Compiled Files
-**/public/stylesheets/*.css
-*.a
-*.o
-*.rbc
-*.so
-*.xcuserdatad
 **/cordova/platforms/android/CordovaLib/ant-build
 **/cordova/platforms/android/CordovaLib/ant-gen
 **/cordova/platforms/android/CordovaLib/bin
@@ -69,6 +63,17 @@ variables.sls
 **/cordova/platforms/wp8/bin
 **/cordova/platforms/wp8/obj
 **/cordova/platforms/wp8/www
+**/public/stylesheets/*.css
+*.a
+*.hmap
+*.ipa
+*.o
+*.rbc
+*.so
+*.xccheckout
+*.xcuserdatad
+DerivedData
+build
 coverage
 coverage.data
 dist
@@ -76,37 +81,71 @@ docs
 files/scripts/**/*.js
 files/scripts/**/*.py
 files/scripts/**/*.zip
+out
+pillars/files
 pkg
+profile
 rdoc
+target
 
 # Local Configuration Files
 !.env.example
+!default.mode1v3
+!default.mode2v3
+!default.pbxuser
+!default.perspectivev3
+**/cordova/platforms/android/CordovaLib/local.properties
+**/cordova/platforms/android/local.properties
+**/settings-local.yml
+**/settings/*-local.yml
 *.bundle
+*.iml
+*.ipr
+*.iws
+*.mode1v3
+*.mode2v3
+*.pbxuser
+*.perspectivev3
 *.project
+*.sublime-project
+*.sublime-workspace
 *.tmproj
+.Rhistory
+.build
 .bundle
-.chamber.pem
-.chamber.pem.enc
+.chamber*.enc
+.chamber*.enc.pass
+.chamber*.pem
 .env
 .env.yml
 .foreman
 .htaccess
 .idea
+.idea_modules
 .powenv
 .powrc
+.pryrc
 .railsrc
 .rspec
 .rvmrc
 .secrets
 .shellwreck.sh
 .terraform
+.tern-port
 Gemfile.local
+Procfile.local
+atlassian-ide-plugin.xml
+com_crashlytics_export_strings.xml
 config.yml
+config/application.yml
 config/database.yml
 config/secrets.yml
-**/cordova/platforms/android/CordovaLib/local.properties
-**/cordova/platforms/android/local.properties
+crashlytics-build.properties
+crashlytics.properties
 nbproject
+xcuserdata
+
+!.circleci/config.yml
 
 # Temporary files
 *.backup
@@ -114,6 +153,7 @@ nbproject
 *.lck
 *.lock
 *.log*
+*.moved-aside
 *.old
 *.orig
 *.sqlite3
@@ -133,8 +173,13 @@ tmp
 # Vagrant
 .vagrant
 
-# Always keep Gemfile.lock
+# Always keep chamber public keys
+!.chamber*.pub.pem
+
+# Always keep lock files
+!yarn.lock
 !Gemfile.lock
+!Cargo.lock
 !composer.lock
 
 # Always Version .keep and .gitkeep files

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,20 +1,64 @@
+# This is an opinionated list of which hooks are valuable to run and what their
+# out-of-the-box settings should be.
+#-------------------------------------------------------------------------------
+
+# Loads Bundler context from a Gemfile. If false, does nothing (default).
+#
+# Specifying a Gemfile for Bundler to load allows you to control which gems are
+# available in the load path (i.e. loadable via `require`) within your hook
+# runs. Note that having a Gemfile requires you to include `overcommit` itself
+# in your Gemfile (otherwise Overcommit can't load itself!).
+#
+# This is useful if you want to:
+#
+#   - Enforce a specific version of Overcommit to use for all hook runs
+#     (or to use a version from the master branch that has not been released yet)
+#   - Enforce a specific version or unreleased branch is used for a gem you want
+#     to use in your git hooks
+#
+# WARNING: This makes your hook runs slower, but you can work around this!
+#
+# Loading a Bundler context necessarily adds a startup delay to your hook runs
+# as Bundler parses the Gemfile and checks that the dependencies are satisfied.
+# Thus for projects with many gems this can introduce a noticeable delay.
+#
+# The recommended workaround is to create a separate Gemfile in the root of your
+# repository (call it `.overcommit_gems.rb`), and include only the gems that
+# your Overcommit hooks need in order to run. This significantly reduces the
+# startup delay in your hook runs. Make sure to commit both
+# `.overcommit_gems.rb` and the resulting `.overcommit_gems.rb.lock` file to
+# your repository, and then set the `gemfile` option below to the name you gave
+# the file.
+# (Generate lock file by running `bundle install --gemfile=.overcommit_gems.rb`)
+gemfile: false
+
 # Where to store hook plugins specific to a repository. These are loaded in
 # addition to the default hooks Overcommit comes with. The location is relative
 # to the root of the repository.
 plugin_directory: '.git-hooks'
 
+# Whether to hide hook output by default. This results in completely silent hook
+# runs except in the case of warning or failure.
+quiet: false
+
+# Number of hooks that can be run concurrently. Typically this won't need to be
+# adjusted, but if you know that some of your hooks themselves use multiple
+# processors you can lower this value accordingly. You can define
+# single-operator mathematical expressions, e.g. '%{processors} * 2', or
+# '%{processors} / 2'.
+concurrency: '%{processors}'
+
 # Whether to check if a hook plugin has changed since Overcommit last ran it.
 # This is a defense mechanism when working with repositories which can contain
 # untrusted code (e.g. when you fetch a pull request from a third party).
-# See https://github.com/causes/overcommit#security for more information.
+# See https://github.com/brigade/overcommit#security for more information.
 verify_signatures: true
 
 PreCommit:
   ALL:
-    problem_on_unmodified_line: report
-    requires_files:           true
-    required:                 false
-    quiet:                    false
+    problem_on_unmodified_line: 'report'
+    requires_files:             true
+    required:                   false
     exclude:
       - 'bower_components/**/*'
       - 'node_modules/**/*'
@@ -35,8 +79,26 @@ PreCommit:
   BrokenSymlinks:
     enabled:                  true
 
+  BundleAudit:
+    enabled:                  true
+    include:
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '*.gemspec'
+
   BundleCheck:
     enabled:                  true
+    include:
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '*.gemspec'
+
+  BundleOutdated:
+    enabled:                  true
+    include:
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '*.gemspec'
 
   CaseConflicts:
     enabled:                  true
@@ -46,6 +108,12 @@ PreCommit:
 
   CoffeeLint:
     enabled:                  true
+
+  Credo:
+    enabled:                  true
+    include:
+      - '**/*.ex'
+      - '**/*.exs'
 
   CssLint:
     enabled:                  true
@@ -59,8 +127,35 @@ PreCommit:
   ExecutePermissions:
     enabled:                  true
     exclude:
+      - 'Rakefile'
       - 'bin/**/*'
-      - 'script/**/*'
+      - 'scripts/**/*'
+
+  Fasterer:
+    enabled:                  false
+    include:
+      - '**/*.rb'
+
+  FixMe:
+    enabled:                  true
+    keywords:
+      - 'BROKEN'
+      - 'BUG'
+      - 'ERROR'
+      - 'FIXME'
+      - 'HACK'
+      - 'NOTE'
+      - 'OPTIMIZE'
+      - 'REVIEW'
+      - 'TODO'
+      - 'WTF'
+      - 'XXX'
+
+  Foodcritic:
+    enabled:                  false
+
+  ForbiddenBranches:
+    enabled:                  false
 
   GoLint:
     enabled:                  true
@@ -78,7 +173,10 @@ PreCommit:
     enabled:                  true
     exclude:
       - '**/*.svg'
+      - '**/Info.plist'
+      - '**/project.pbxproj'
       - '**/structure.sql'
+      - '**/xcschememanagement.plist'
 
   HtmlHint:
     enabled:                  true
@@ -93,7 +191,7 @@ PreCommit:
     enabled:                  true
 
   Jscs:
-    enabled:                  true
+    enabled:                  false
 
   JsHint:
     enabled:                  false
@@ -107,14 +205,29 @@ PreCommit:
   JsonSyntax:
     enabled:                  true
 
+  LicenseHeader:
+    enabled:                  false
+    licence_file:             'LICENSE.txt'
+
+  LineEndings:
+    enabled:                  true
+
   LocalPathsInGemfile:
     enabled:                  true
+
+  Mdl:
+    enabled:                  true
+    include:
+      - '**/*.md'
 
   MergeConflicts:
     enabled:                  true
 
-  Minitest:
-    enabled:                  false
+  MessageFormat:
+    enabled:                  true
+    pattern:                  '(Add|Fix|Change|Remove|Deprecate|Security|Docs|Style|Tests|Chore|WIP):\s'
+    expected_pattern_message: '<Change Type>: <Commit Message Description>'
+    sample_message:           'Chore: Refactor onboarding flow'
 
   NginxTest:
     enabled:                  true
@@ -197,6 +310,11 @@ PreCommit:
   TravisLint:
     enabled:                  true
 
+  TsLint:
+    enabled:                  true
+    include:
+      - '**/*.ts'
+
   Vint:
     enabled:                  true
 
@@ -212,6 +330,12 @@ PreCommit:
   XmlSyntax:
     enabled:                  true
 
+  YamlLint:
+    enabled:                  false
+    include:
+      - '**/*.yaml'
+      - '**/*.yml'
+
   YamlSyntax:
     enabled:                  true
 
@@ -219,7 +343,9 @@ PrePush:
   ALL:
     requires_files:           false
     required:                 false
-    quiet:                    false
+
+  Minitest:
+    enabled:                  false
 
   ProtectedBranches:
     enabled:                  false
@@ -231,7 +357,6 @@ PreRebase:
   ALL:
     requires_files:           false
     required:                 false
-    quiet:                    false
 
   MergedCommits:
     enabled:                  false
@@ -239,10 +364,12 @@ PreRebase:
 CommitMsg:
   ALL:
     requires_files:           false
-    quiet:                    false
 
   CapitalizedSubject:
     enabled:                  true
+
+  Commitplease:
+    enabled:                  false
 
   EmptyMessage:
     enabled:                  false
@@ -273,7 +400,7 @@ CommitMsg:
 PostCheckout:
   ALL:
     required:                 false
-    quiet:                    false
+    skip_file_checkout:       true
 
   BowerInstall:
     enabled:                  false
@@ -294,7 +421,6 @@ PostCommit:
   ALL:
     requires_files:           false
     required:                 false
-    quiet:                    false
 
   BowerInstall:
     enabled:                  false
@@ -316,8 +442,8 @@ PostCommit:
 
 PostMerge:
   ALL:
+    enabled:                  false
     requires_files:           false
-    quiet:                    false
 
   BowerInstall:
     enabled:                  false
@@ -332,12 +458,11 @@ PostMerge:
     enabled:                  false
 
   SubmoduleStatus:
-    enabled:                  true
+    enabled:                  false
 
 PostRewrite:
   ALL:
     requires_files:           false
-    quiet:                    false
 
   BowerInstall:
     enabled:                  false

--- a/.rubocop_core.yml
+++ b/.rubocop_core.yml
@@ -1,4 +1,4 @@
-# Last updated to rubocop 0.52.1
+# Last updated to rubocop 0.53.0
 
 AllCops:
   Include:
@@ -56,9 +56,6 @@ AllCops:
     - '**/db/migrate/**/*'
     - '**/db/schema.rb'
     - '**/node_modules/**/*'
-    - '**/sample.rb'
-    - '**/scrub.rb'
-    - '**/seed.rb'
     - '**/spec/dummy/**/*'
     - '**/vendor/**/*'
     - 'bin/rails'
@@ -124,6 +121,14 @@ Layout/AlignParameters:
   Exclude:
     - '**/Gemfile'
 
+Layout/BlockAlignment:
+  Enabled:                                    true
+  EnforcedStyleAlignWith:                     'either'
+  Exclude:
+    - '**/spec/factories.rb'
+    - '**/spec/factories/**/*.rb'
+    - 'app/controllers/**/*.rb'
+
 Layout/BlockEndNewline:
   Enabled:                                    true
 
@@ -135,56 +140,43 @@ Layout/CaseIndentation:
 
 Layout/ClassStructure:
   Enabled:                                    true
-  Categories:
-    accessors:
-      - 'cattr_accessor'
-      - 'cattr_reader'
-      - 'cattr_writer'
-      - 'attr_accessor'
-      - 'attr_reader'
-      - 'attr_writer'
-    associations:
-      - 'has_and_belongs_to_many'
-      - 'belongs_to'
-      - 'has_one'
-      - 'has_many'
-    callbacks:
-      - 'before_validation'
-      - 'after_validation'
-      - 'before_save'
-      - 'before_create'
-      - 'after_create'
-      - 'after_save'
-      - 'after_commit'
-    delegations:
-      - 'delegate'
-    module_inclusions:
-      - 'prepend'
-      - 'include'
-      - 'extend'
-    scopes:
-      - 'default_scope'
-      - 'scope'
-    serializations:
-      - 'serialize'
-    validations:
-      - 'validate'
-      - 'validates'
   ExpectedOrder:
-      - 'module_inclusion'
-      - 'constants'
-      - 'accessors'
-      - 'delegations'
-      - 'serializations'
-      - 'associations'
-      - 'validations'
-      - 'callbacks'
-      - 'scopes'
-      - 'public_class_methods'
-      - 'initializer'
-      - 'public_methods'
-      - 'protected_methods'
-      - 'private_methods'
+    - 'prepend'
+    - 'include'
+    - 'extend'
+    - 'constants'
+    - 'cattr_accessor'
+    - 'cattr_reader'
+    - 'cattr_writer'
+    - 'attr_accessor'
+    - 'attr_reader'
+    - 'attr_writer'
+    - 'delegate'
+    - 'serialize'
+    - 'belongs_to'
+    - 'has_one'
+    - 'has_many'
+    - 'has_and_belongs_to_many'
+    - 'validates'
+    - 'validate'
+    - 'before_validation'
+    - 'after_validation'
+    - 'before_save'
+    - 'before_create'
+    - 'after_create'
+    - 'after_save'
+    - 'after_commit'
+    - 'default_scope'
+    - 'scope'
+    - 'accepts_nested_attributes_for'
+    - 'friendly_id'
+    - 'geocoded_by'
+    - 'has_attached_file'
+    - 'public_class_methods'
+    - 'initializer'
+    - 'public_methods'
+    - 'protected_methods'
+    - 'private_methods'
 
 Layout/ClosingParenthesisIndentation:
   Enabled:                                    false # Disallows Alignment with Opening Paren: my_method(
@@ -197,12 +189,25 @@ Layout/CommentIndentation:
   Exclude:
     - '**/config/initializers/middleware.rb'
 
+Layout/ConditionPosition:
+  Enabled:                                    true
+
+Layout/DefEndAlignment:
+  Enabled:                                    true
+  EnforcedStyleAlignWith:                     'start_of_line'
+  AutoCorrect:                                true
+
 Layout/DotPosition:
   Enabled:                                    true
   EnforcedStyle:                              'leading'
 
 Layout/ElseAlignment:
   Enabled:                                    true
+
+Layout/EmptyComment:
+  Enabled:                                    true
+  AllowBorderComment:                         true
+  AllowMarginComment:                         true
 
 Layout/EmptyLineAfterMagicComment:
   Enabled:                                    true
@@ -244,6 +249,11 @@ Layout/EmptyLinesAroundModuleBody:
 
 Layout/EmptyLines:
   Enabled:                                    true
+
+Layout/EndAlignment:
+  Enabled:                                    true
+  EnforcedStyleAlignWith:                     'keyword'
+  AutoCorrect:                                true
 
 Layout/EndOfLine:
   Enabled:                                    true
@@ -408,6 +418,7 @@ Layout/SpaceInLambdaLiteral:
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled:                                    true
   EnforcedStyle:                              'no_space'
+  EnforcedStyleForEmptyBrackets:              'no_space'
 
 Layout/SpaceInsideArrayPercentLiteral:
   Enabled:                                    true
@@ -435,6 +446,7 @@ Layout/SpaceInsideRangeLiteral:
 Layout/SpaceInsideReferenceBrackets:
   Enabled:                                    true
   EnforcedStyle:                              'no_space'
+  EnforcedStyleForEmptyBrackets:              'no_space'
 
 Layout/SpaceInsideStringInterpolation:
   Enabled:                                    true
@@ -470,10 +482,8 @@ Lint/AssignmentInCondition:
   Enabled:                                    true
   AllowSafeAssignment:                        true
 
-Lint/BlockAlignment:
+Lint/BigDecimalNew:
   Enabled:                                    true
-  Exclude:
-    - 'app/controllers/**/*.rb'
 
 Lint/BooleanSymbol:
   Enabled:                                    true
@@ -481,16 +491,8 @@ Lint/BooleanSymbol:
 Lint/CircularArgumentReference:
   Enabled:                                    true
 
-Lint/ConditionPosition:
-  Enabled:                                    true
-
 Lint/Debugger:
   Enabled:                                    true
-
-Lint/DefEndAlignment:
-  Enabled:                                    true
-  EnforcedStyleAlignWith:                     'start_of_line'
-  AutoCorrect:                                true
 
 Lint/DeprecatedClassMethods:
   Enabled:                                    true
@@ -515,11 +517,6 @@ Lint/EmptyInterpolation:
 
 Lint/EmptyWhen:
   Enabled:                                    true
-
-Lint/EndAlignment:
-  Enabled:                                    true
-  EnforcedStyleAlignWith:                     'keyword'
-  AutoCorrect:                                true
 
 Lint/EndInMethod:
   Enabled:                                    true
@@ -565,6 +562,9 @@ Lint/NestedMethodDefinition:
   Enabled:                                    true
 
 Lint/NonLocalExitFromIterator:
+  Enabled:                                    true
+
+Lint/OrderedMagicComments:
   Enabled:                                    true
 
 Lint/ParenthesesAsGroupedExpression:
@@ -624,7 +624,10 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled:                                    true
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
+  Enabled:                                    true
+
+Lint/UnneededCopEnableDirective:
   Enabled:                                    true
 
 Lint/UnneededRequireStatement:
@@ -677,6 +680,8 @@ Lint/Void:
 Metrics/AbcSize:
   Enabled:                                    true
   Max:                                        25.0
+  Exclude:
+    - '**/db/sample.rb'
 
 Metrics/BlockNesting:
   Enabled:                                    true
@@ -694,12 +699,15 @@ Metrics/BlockLength:
   CountComments:                              false
   Max:                                        25
   Exclude:
-    - 'Rakefile'
     - '**/*.rake'
     - '**/config/routes.rb'
+    - '**/db/sample.rb'
+    - '**/db/scrub.rb'
+    - '**/db/seed.rb'
     - '**/spec/**/*_spec.rb'
     - '**/spec/**/factories/*.rb'
     - '**/spec/factories.rb'
+    - 'Rakefile'
   ExcludedMethods:
     - 'namespace'
     - 'draw'
@@ -758,14 +766,22 @@ Metrics/LineLength:
     - 'https'
   Exclude:
     - '**/Gemfile'
-    - '**/config/routes.rb'
     - '**/config/environments/**/*'
     - '**/config/initializers/**/*'
+    - '**/config/routes.rb'
+    - '**/db/sample.rb'
+    - '**/db/scrub.rb'
+    - '**/db/seed.rb'
+    - '**/factories/*.rb'
 
 Metrics/MethodLength:
   Enabled:                                    true
   CountComments:                              false
   Max:                                        30
+  Exclude:
+    - '**/db/sample.rb'
+    - '**/db/scrub.rb'
+    - '**/db/seed.rb'
 
 Metrics/ParameterLists:
   Enabled:                                    true
@@ -817,6 +833,9 @@ Naming/HeredocDelimiterCase:
   Enabled:                                    true
   EnforcedStyle:                              'uppercase'
 
+Naming/MemoizedInstanceVariableName:
+  Enabled:                                    true
+
 Naming/MethodName:
   Enabled:                                    true
   EnforcedStyle:                              'snake_case'
@@ -839,6 +858,22 @@ Naming/PredicateName:
     - 'define_singleton_method'
   Exclude:
     - 'spec/**/*'
+
+Naming/UncommunicativeBlockParamName:
+  Enabled:                                    true
+  MinNameLength:                              1
+  AllowNamesEndingInNumbers:                  true
+  AllowedNames:                               []
+  ForbiddenNames:                             []
+
+Naming/UncommunicativeMethodParamName:
+  Enabled:                                    true
+  MinNameLength:                              3
+  AllowNamesEndingInNumbers:                  true
+  AllowedNames:
+    - 'io'
+    - 'id'
+  ForbiddenNames:                             []
 
 Naming/VariableName:
   Enabled:                                    true
@@ -882,10 +917,6 @@ Performance/FixedSize:
 
 Performance/FlatMap:
   Enabled:                                    true
-
-Performance/HashEachMethods:
-  Enabled:                                    true
-  AutoCorrect:                                true
 
 Performance/LstripRstrip:
   Enabled:                                    true
@@ -945,6 +976,9 @@ Security/JSONLoad:
   Exclude:
     - '**/spec/**/*.rb'
 
+Security/Open:
+  Enabled:                                    true
+
 Security/YAMLLoad:
   Enabled:                                    true
   Exclude:
@@ -994,6 +1028,8 @@ Style/BlockDelimiters:
   Enabled:                                    true
   EnforcedStyle:                              'braces_for_chaining'
   Exclude:
+    - '**/spec/factories.rb'
+    - '**/spec/factories/**/*.rb'
     - 'app/controllers/**/*.rb'
 
 Style/BracesAroundHashParameters:
@@ -1094,6 +1130,9 @@ Style/EmptyElse:
   Enabled:                                    true
   EnforcedStyle:                              'both'
 
+Style/EmptyLineAfterGuardClause:
+  Enabled:                                    true
+
 Style/EmptyLiteral:
   Enabled:                                    true
   Exclude:
@@ -1108,6 +1147,9 @@ Style/Encoding:
   Enabled:                                    true
 
 Style/EndBlock:
+  Enabled:                                    true
+
+Style/ExpandPathArguments:
   Enabled:                                    true
 
 Style/EvalWithLocation:
@@ -1513,14 +1555,24 @@ Style/TernaryParentheses:
   AllowSafeAssignment:                        true
   EnforcedStyle:                              'require_parentheses_when_complex'
 
+Style/TrailingBodyOnClass:
+  Enabled:                                    true
+
 Style/TrailingBodyOnMethodDefinition:
+  Enabled:                                    true
+
+Style/TrailingBodyOnModule:
   Enabled:                                    true
 
 Style/TrailingCommaInArguments:
   Enabled:                                    true
   EnforcedStyleForMultiline:                  'comma'
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled:                                    true
+  EnforcedStyleForMultiline:                  'comma'
+
+Style/TrailingCommaInHashLiteral:
   Enabled:                                    true
   EnforcedStyleForMultiline:                  'comma'
 

--- a/.rubocop_core.yml
+++ b/.rubocop_core.yml
@@ -1130,7 +1130,7 @@ Style/EmptyElse:
   Enabled:                                    true
   EnforcedStyle:                              'both'
 
-Style/EmptyLineAfterGuardClause:
+Layout/EmptyLineAfterGuardClause:
   Enabled:                                    true
 
 Style/EmptyLiteral:

--- a/.rubocop_rspec.yml
+++ b/.rubocop_rspec.yml
@@ -1,0 +1,106 @@
+# Last updated to 1.10
+
+require:
+  - 'rubocop-rspec'
+
+RSpec/AnyInstance:
+  Enabled:                        true
+
+RSpec/BeEql:
+  Enabled:                        true
+
+RSpec/DescribeClass:
+  Enabled:                        true
+
+RSpec/DescribeMethod:
+  Enabled:                        true
+
+RSpec/DescribedClass:
+  Enabled:                        false
+
+RSpec/EmptyExampleGroup:
+  Enabled:                        false
+  CustomIncludeMethods:           []
+
+RSpec/ExampleLength:
+  Enabled:                        false
+  Max:                            50
+
+RSpec/ExampleWording:
+  Enabled:                        true
+
+RSpec/ExpectActual:
+  Enabled:                        true
+
+RSpec/ExpectOutput:
+  Enabled:                        true
+
+RSpec/FilePath:
+  Enabled:                        false
+
+RSpec/Focus:
+  Enabled:                        true
+
+RSpec/HookArgument:
+  Enabled:                        true
+  EnforcedStyle:                  'each'
+
+RSpec/ImplicitExpect:
+  Enabled:                        true
+  EnforcedStyle:                  'is_expected'
+
+RSpec/InstanceVariable:
+  Enabled:                        true
+
+RSpec/LeadingSubject:
+  Enabled:                        true
+
+RSpec/LetSetup:
+  Enabled:                        true
+
+RSpec/MessageChain:
+  Enabled:                        true
+
+RSpec/MessageExpectation:
+  Enabled:                        true
+  EnforcedStyle:                  'allow'
+
+RSpec/MessageSpies:
+  Enabled:                        true
+  EnforcedStyle:                  'have_received'
+
+RSpec/MultipleDescribes:
+  Enabled:                        true
+
+RSpec/MultipleExpectations:
+  Enabled:                        false
+  Max:                            5
+
+RSpec/NamedSubject:
+  Enabled:                        true
+
+RSpec/NestedGroups:
+  Enabled:                        true
+  Max:                            1
+
+RSpec/NotToNot:
+  Enabled:                        true
+  EnforcedStyle:                  'not_to'
+
+RSpec/RepeatedDescription:
+  Enabled:                        true
+
+RSpec/RepeatedExample:
+  Enabled:                        true
+
+RSpec/ScatteredSetup:
+  Enabled:                        true
+
+RSpec/SingleArgumentMessageChain:
+  Enabled:                        true
+
+RSpec/SubjectStub:
+  Enabled:                        true
+
+RSpec/VerifiedDoubles:
+  Enabled:                        true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fuubar.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,29 +6,29 @@ PATH
       ruby-progressbar (~> 1.4)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    awesome_print (1.7.0)
-    chamber (2.8.0)
+    awesome_print (1.8.0)
+    chamber (2.12.3)
       hashie (~> 3.3)
-      thor (~> 0.19.1)
-    diff-lcs (1.2.5)
-    hashie (3.4.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.1)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+      thor (>= 0.19.1, < 0.21)
+    diff-lcs (1.3)
+    hashie (3.5.7)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
-    ruby-progressbar (1.8.0)
-    thor (0.19.1)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    ruby-progressbar (1.9.0)
+    thor (0.20.0)
 
 PLATFORMS
   ruby
@@ -40,4 +40,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.12.5
+   1.16.1

--- a/fuubar.gemspec
+++ b/fuubar.gemspec
@@ -6,25 +6,24 @@ Gem::Specification.new do |spec|
   spec.name          = 'fuubar'
   spec.version       = '2.3.1'
   spec.authors       = ['Nicholas Evans', 'Jeff Kreeftmeijer', 'jfelchner']
-  spec.email         = '["jeff@kreeftmeijer.nl", "accounts+git@thekompanee.com"]'
+  spec.email         = ['jeff@kreeftmeijer.nl', 'accounts+git@thekompanee.com']
   spec.summary       = %q{the instafailing RSpec progress bar formatter}
   spec.description   = %q{the instafailing RSpec progress bar formatter}
   spec.homepage      = 'https://github.com/thekompanee/fuubar'
-  spec.license       = 'MIT'
+  spec.licenses      = ['MIT']
 
-  spec.cert_chain    = %w{certs/thekompanee.pem}
+  spec.cert_chain    = ['certs/thekompanee.pem']
   spec.signing_key   = File.expand_path('~/.gem/certs/thekompanee-private_key.pem') if $0 =~ /gem\z/
 
-  spec.executables   = %w{}
+  spec.executables   = []
   spec.files         = Dir['{app,config,db,lib,templates}/**/*'] + %w{README.md LICENSE.txt}
-  spec.test_files    = Dir['{test,spec,features}/**/*']
-
-  spec.add_dependency             'rspec-core', ["~> 3.0"]
-  spec.add_dependency             'ruby-progressbar', ["~> 1.4"]
-
-  spec.add_development_dependency 'rspec', ["~> 3.0"]
-  spec.add_development_dependency 'chamber', ["~> 2.3"]
-  spec.add_development_dependency 'awesome_print', ["~> 1.7"]
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+
+  spec.add_dependency             'rspec-core',       ["~> 3.0"]
+  spec.add_dependency             'ruby-progressbar', ["~> 1.4"]
+
+  spec.add_development_dependency 'rspec',            ["~> 3.0"]
+  spec.add_development_dependency 'chamber',          ["~> 2.3"]
+  spec.add_development_dependency 'awesome_print',    ["~> 1.7"]
 end


### PR DESCRIPTION
<!--- Well formatted issues help everyone.  Take a few minutes to get a -->
<!--- primer on markdown here: http://bit.ly/2lB1raW -->

## Why This Change Is Necessary

<!--- Identify the High Level Type of Change -->
- [x] Bug Fix
- [ ] New Feature

<!--- Now describe to reviewers of your pull request what to expect in the -->
<!--- PR, thereby allowing them to more easily identify and point out -->
<!--- unrelated changes. -->

## How These Changes Address the Issue
This PR fixes updated namespace for `Layout/EmptyLineAfterGuardClause` cop (https://github.com/rubocop-hq/rubocop/pull/5886)
<!--- Describe, at a high level, what was done to affect change. -->
<!--- If your change is obvious, you may be able to omit addressing this. -->

## Screenshots
<!--- Add screenshots of changes to the UI if appropriate, otherwise delete -->
<!--- this section. -->
<img width="841" alt="2018-08-02 00 34 26" src="https://user-images.githubusercontent.com/8161569/43550407-22441d92-95ec-11e8-8575-d75e21d3f542.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that -->
<!--- apply. -->
- [x] I have run `rubocop` against the codebase
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
