### PR TITLE
Allow fuubar to suppress rspec summary, failure dump, pending dump, and messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,5 @@ group :console do
   gem 'awesome_print', '~> 1.7'
 end
 
-group :development do
-  gem 'rubocop', '~> 0.60.0'
-end
-
 # Specify your gem's dependencies in fuubar.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,9 @@ group :console do
   gem 'awesome_print', '~> 1.7'
 end
 
+group :development do
+  gem 'rubocop', '~> 0.60.0'
+end
+
 # Specify your gem's dependencies in fuubar.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,4 +51,4 @@ DEPENDENCIES
   rubocop (~> 0.60.0)
 
 BUNDLED WITH
-   2.0.1
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,22 +8,38 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
     awesome_print (1.8.0)
     diff-lcs (1.3)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    jaro_winkler (1.5.2)
+    parallel (1.14.0)
+    parser (2.6.0.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    ruby-progressbar (1.9.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    rubocop (0.60.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
+    unicode-display_width (1.4.1)
 
 PLATFORMS
   ruby
@@ -32,6 +48,7 @@ DEPENDENCIES
   awesome_print (~> 1.7)
   fuubar!
   rspec (~> 3.7)
+  rubocop (~> 0.60.0)
 
 BUNDLED WITH
-   1.16.2
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
     awesome_print (1.8.0)
     diff-lcs (1.3)
-    jaro_winkler (1.5.2)
-    parallel (1.14.0)
-    parser (2.6.0.0)
-      ast (~> 2.4.0)
-    powerpack (0.1.2)
-    rainbow (3.0.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -30,16 +23,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.60.0)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    unicode-display_width (1.4.1)
 
 PLATFORMS
   ruby
@@ -48,7 +32,6 @@ DEPENDENCIES
   awesome_print (~> 1.7)
   fuubar!
   rspec (~> 3.7)
-  rubocop (~> 0.60.0)
 
 BUNDLED WITH
    1.16.2

--- a/lib/fuubar.rb
+++ b/lib/fuubar.rb
@@ -6,12 +6,10 @@ require 'ruby-progressbar'
 require 'fuubar/output'
 
 RSpec.configuration.add_setting :fuubar_progress_bar_options, :default => {}
-RSpec.configuration.add_setting :fuubar_output_options, :default => {
-  :summary        => true,
-  :failure_detail => true,
-  :pending_detail => true,
-  :messages       => true
-}
+RSpec.configuration.add_setting :fuubar_output_summary, :default => true
+RSpec.configuration.add_setting :fuubar_output_failure_detail, :default => true
+RSpec.configuration.add_setting :fuubar_output_pending_detail, :default => true
+RSpec.configuration.add_setting :fuubar_output_messages, :default => true
 
 class Fuubar < RSpec::Core::Formatters::BaseTextFormatter
   DEFAULT_PROGRESS_BAR_OPTIONS = { :format => ' %c/%C |%w>%i| %e ' }.freeze
@@ -81,7 +79,7 @@ class Fuubar < RSpec::Core::Formatters::BaseTextFormatter
 
   def dump_summary(summary)
     # Suppresses Summary View based on options
-    output.puts summary.fully_formatted if configuration.fuubar_output_options[:summary]
+    output.puts summary.fully_formatted if configuration.fuubar_output_summary
   end
 
   def example_passed(_notification)
@@ -99,7 +97,7 @@ class Fuubar < RSpec::Core::Formatters::BaseTextFormatter
   def example_failed(notification)
     self.failed_count += 1
     # Suppresses Failure Detail View based on options
-    if configuration.fuubar_output_options[:failure_detail]
+    if configuration.fuubar_output_failure_detail
       progress.clear
 
       output.puts notification.fully_formatted(failed_count)
@@ -117,7 +115,7 @@ class Fuubar < RSpec::Core::Formatters::BaseTextFormatter
 
   def message(notification)
     # Suppresses Messages View based on options
-    return unless configuration.fuubar_output_options[:messages]
+    return unless configuration.fuubar_output_messages
 
     if progress.respond_to? :log
       progress.log(notification.message)
@@ -135,7 +133,7 @@ class Fuubar < RSpec::Core::Formatters::BaseTextFormatter
 
   def dump_pending(notification)
     # Suppresses Pending Detail View based on options
-    return unless configuration.fuubar_output_options[:pending_detail] && notification.pending_examples.empty?
+    return unless configuration.fuubar_output_pending_detail && notification.pending_examples.empty?
 
     output.puts notification.fully_formatted_pending_examples
   end

--- a/lib/fuubar.rb
+++ b/lib/fuubar.rb
@@ -133,7 +133,8 @@ class Fuubar < RSpec::Core::Formatters::BaseTextFormatter
 
   def dump_pending(notification)
     # Suppresses Pending Detail View based on options
-    return unless configuration.fuubar_output_pending_detail && notification.pending_examples.empty?
+    return unless configuration.fuubar_output_pending_detail
+    return if notification.pending_examples.empty?
 
     output.puts notification.fully_formatted_pending_examples
   end


### PR DESCRIPTION
Why This Change Is Necessary
--------------------------------------------------------------------------------
I wanted to use fuubar to get a progress bar of my specs, but suppress some of the default rspec sections like the summary, failures dump, and pending examples dump.

<!--- Identify the High Level Type of Change -->
- [ ] Bug Fix
- [X] New Feature

<!---
  Now describe to reviewers of your pull request what to expect in the PR,
  thereby allowing them to more easily identify and point out unrelated changes.
-->

How These Changes Address the Issue
--------------------------------------------------------------------------------
I added the `fuubar_output_options` and set defaults to true, so when no options are passed there is no change to the functionality of the gem. But if you pass all of the new options like so:

```ruby
config.fuubar_output_summary = false
config.fuubar_output_failure_detail = false
config.fuubar_output_pending_detail = false
config.fuubar_output_messages = false
```
Then only the progress bar will appear as output from the formatter.

<!---
  Describe, at a high level, what was done to affect change. If your change is
  obvious, you may be able to omit addressing this.
-->

Side Effects Caused By This Change
--------------------------------------------------------------------------------
None

- [ ] This Causes a Breaking Change
- [X] This Does Not Cause Any Known Side Effects

<!---
  This is the most important topic to answer, as it can point out problems where
  you are making too many changes in one commit or branch. One or two bullet
  points for related changes may be okay, but five or six are likely indicators
  of a PR that is doing too many things.
-->


Checklist:
--------------------------------------------------------------------------------
<!---
  Go over all the following points, and put an `x` in all the boxes that apply.
-->

- [X] I have run `rubocop` against the codebase
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

<!---

NOTES
================================================================================

Markdown
--------------------------------------------------------------------------------

Well formatted issues help everyone. Take a few minutes to get a primer on
markdown here: http://bit.ly/2lB1raW

Images
--------------------------------------------------------------------------------

Images can be attached to this issue by dragging and dropping or by copying and
pasting.

* How to Add Images to Issues: http://bit.ly/2mdlWHn
* How to Take Screenshots (Mac): http://apple.co/2kOXyuG
* How to Take Screenshots (Windows): http://cnet.co/2m2yQZL

-->
