### PR TITLE
Change: Stop Auto-Refresh When A Pry Session Starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,23 +94,54 @@ RSpec.configure do |config|
 end
 ```
 
-### Disabling Auto-Refresh ###
+### Enabling Auto-Refresh ###
 
-By default fuubar will automatically refresh the bar (and therefore the ETA)
-every second.  Unfortunately this doesn't play well with things like debuggers.
-When you're debugging, having a bar show up every second is undesireable.
-[Pry][pry] gives us hooks so that we can automatically disable the refresh when
-it's used. Unfortunately [byebug][byebug] does not and disabling the bar must be
-done manually.
+By default fuubar refreshes the bar only between each spec.
+You can enable an auto-refresh feature that will keep refreshing the bar (and
+therefore the ETA) every second.
+You can enable the feature as follows:
 
-#### Example ####
 
 ```ruby
 # spec/spec_helper.rb
 
 RSpec.configure do |config|
-  config.fuubar_auto_refresh = false
+  config.fuubar_auto_refresh = true
 end
+```
+
+#### Undesirable effects
+
+Unfortunately this option doesn't play well with things like debuggers, as
+having a bar show up every second would be undesireable (which is why the
+feature is disabled by default). Depending on what you are using, you may be
+given ways to work around this problem.
+
+##### Pry
+
+[Pry][pry] provides hooks that can be used to disable fuubar during a debugging
+session, you could for example add the following to your spec helper:
+
+```ruby
+# spec/spec_helper.rb
+
+Pry.config.hooks.add_hook(:before_session, :disable_fuubar_auto_refresh) do |_output, _binding, _pry|
+  RSpec.configuration.fuubar_auto_refresh = false
+end
+
+Pry.config.hooks.add_hook(:after_session, :restore_fuubar_auto_refresh) do |_output, _binding, _pry|
+  RSpec.configuration.fuubar_auto_refresh = true
+end
+```
+
+##### Byebug
+
+Unfortunately [byebug][byebug] does not provide hooks, so your best bet is to
+disable auto-refresh manually before calling `byebug`.
+
+```ruby
+RSpec.configuration.fuubar_auto_refresh = false
+byebug
 ```
 
 Security

--- a/lib/fuubar.rb
+++ b/lib/fuubar.rb
@@ -6,17 +6,8 @@ require 'ruby-progressbar'
 require 'fuubar/output'
 
 RSpec.configuration.add_setting :fuubar_progress_bar_options,   :default => {}
-RSpec.configuration.add_setting :fuubar_auto_refresh,           :default => true
+RSpec.configuration.add_setting :fuubar_auto_refresh,           :default => false
 RSpec.configuration.add_setting :fuubar_output_pending_results, :default => true
-
-if Object.const_defined?('Pry')
-  Pry.
-    config.
-    hooks.
-    add_hook(:when_started, :fuubar_kill_refresh) do |_target, _opt, _|
-      RSpec.configuration.fuubar_auto_refresh = false
-    end
-end
 
 class Fuubar < RSpec::Core::Formatters::BaseTextFormatter
   DEFAULT_PROGRESS_BAR_OPTIONS = { :format => ' %c/%C |%w>%i| %e ' }.freeze


### PR DESCRIPTION
Why This Change Is Necessary
========================================================================

The problem with #105 was that the Pry-related code was running as soon
as the `fuubar` gem got loaded, which can be before `Pry` is defined (if
the `pry` gem gets loaded later).

*Note:* In general, having fuubar depend on any externally loaded
libraries is undesirable. Because each individual installation can have
an infinite combination of gems, how those gems interact should be left
to the user (within reason).

How These Changes Address the Issue
========================================================================

We remove all of the Pry hooks and then add documentation how the user
can enable auto-refresh using Pry's debugger.

We then disable auto-refresh by default and allow the user to opt-in to
potentially surprising behavior rather than having to opt-out of it.

Side Effects Caused By This Change
========================================================================

Prior users who depend on auto-refresh may be surprised that it no
longer does it.

Caveats
========================================================================

There still is at least one limitation: if the `pry` gem is added to the
Gemfile with the option `require: false`, then required too late for
Fuubar to know, then the hooks will not be added, and auto-refresh will
keep happening when the Pry session opens.

------------------------------------------------------------------------
My Tracker Issue URLs:
  * https://github.com/thekompanee/fuubar/issues/105
Actions:
  * Fixes #108
Branch:        pry_auto_refresh