### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/fuubar.gemspec
+++ b/fuubar.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
     'homepage_uri'      => 'https://github.com/thekompanee/fuubar',
     'source_code_uri'   => 'https://github.com/thekompanee/fuubar',
     'wiki_uri'          => 'https://github.com/thekompanee/fuubar/wiki',
+    'funding_uri'       => 'https://github.com/sponsors/jfelchner',
   }
 
   spec.add_dependency             'rspec-core',       ["~> 3.0"]


### PR DESCRIPTION
Added your github sponsors link to `funding_uri` in gemspec to help increase visibility using the `bundle fund` command in Bundler.