### PR TITLE
Prepare code for RSpec 4

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---color
 --format Fuubar

--- a/lib/fuubar.rb
+++ b/lib/fuubar.rb
@@ -126,7 +126,7 @@ class Fuubar < ::RSpec::Core::Formatters::BaseTextFormatter
   end
 
   def output
-    @fuubar_output ||= ::Fuubar::Output.new(super, configuration.tty?) # rubocop:disable Naming/MemoizedInstanceVariableName
+    @fuubar_output ||= ::Fuubar::Output.new(super, configuration.color_enabled?) # rubocop:disable Naming/MemoizedInstanceVariableName
   end
 
   private

--- a/spec/lib/fuubar/output_spec.rb
+++ b/spec/lib/fuubar/output_spec.rb
@@ -19,7 +19,7 @@ class TestTtyOutputClass
 end
 
 class    Fuubar < ::RSpec::Core::Formatters::BaseTextFormatter
-describe Output do
+RSpec.describe Output do
   it 'delegates anything to the passed in object' do
     output = Output.new(::TestTtyOutputClass.new)
 

--- a/spec/lib/fuubar_spec.rb
+++ b/spec/lib/fuubar_spec.rb
@@ -2,10 +2,9 @@
 
 require 'fuubar'
 require 'stringio'
-require 'ostruct'
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers
-describe ::Fuubar do
+RSpec.describe ::Fuubar do
   let(:output) do
     io = ::StringIO.new
 
@@ -61,11 +60,11 @@ describe ::Fuubar do
 
   context 'when it is created' do
     it 'does not start the bar until the formatter is started' do
-      expect(formatter.progress).not_to be_started
+      expect(formatter.progress.started?).to be_falsey
 
       formatter.start(start_notification)
 
-      expect(formatter.progress).to be_started
+      expect(formatter.progress.started?).to be_truthy
     end
 
     it 'creates a new ProgressBar' do


### PR DESCRIPTION
---

name:  Pull Request
about: Describe the changes you would like to make

---

<!--lint ignore first-heading-level-->

Why This Change Is Necessary
--------------------------------------------------------------------------------

<!-- Identify the High Level Type of Change -->

* [ ] Bug Fix
* [ ] New Feature

The next major version of RSpec is getting close to release; version 4.0.0.beta1 was released a couple of days ago. Some deprecated code was removed (`configuration.tty?`), predicate matchers must return booleans (so `be_started` doesn't work) and RSpec no longer does global monkey patching (which now requires the explicit receiver on `RSpec.describe`).

How These Changes Address the Issue
--------------------------------------------------------------------------------

See the previous section.

I didn't add RSpec 4 to CI, because I found the CI setup too complicated and outdated (sorry), and I think clearing that up requires a separate pull request.

Side Effects Caused By This Change
--------------------------------------------------------------------------------

* [ ] This Causes a Breaking Change
* [x] This Does Not Cause Any Known Side Effects

I _think_ all the changes work with RSpec 3.0, but since the gemspec requires v3.7 or newer to run its own specs, I have not tested with older versions.

Screenshots
--------------------------------------------------------------------------------

<!--
  Add screenshots of changes to the UI if appropriate, otherwise delete this
  section.
-->

Checklist
--------------------------------------------------------------------------------

<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->

* [ ] I have run `rubocop` against the codebase
* [x] I have added tests to cover my changes
* [x] All new and existing tests passed

I couldn’t get RuboCop to run, but I’ll look into making a separate PR fixing CI setup.